### PR TITLE
Add AI Detector Arena Benchmark to Datasets section

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Changing What You Want, [[paper]](http://vipl.ict.ac.cn/uploadfile/upload/201911
 + SVM: Exposing Deep Fakes Using Inconsistent Head Poses, [[paper]](https://ieeexplore.ieee.org/document/8683164)
  
  ## Datasets
++ [AI Detector Arena Benchmark](https://aidetectarena.com/benchmark-dataset) - Standardized benchmark for evaluating AI-generated image detectors. 2,038 images (1,018 AI-generated, 1,020 real) across 17 generators and 6 categories with live leaderboard. [[DOI]](https://doi.org/10.5281/zenodo.18620634)
 + [Google Deepfake Detection Dataset](https://github.com/ondyari/FaceForensics/tree/master/dataset)
 + [FaceForensics++ Dataset](https://github.com/ondyari/FaceForensics/tree/master/dataset)
 + [Facebook Deepfake Detection Challenge (DFDC) Dataset](https://www.kaggle.com/c/deepfake-detection-challenge/data)


### PR DESCRIPTION
## Summary

Adding **AI Detector Arena Benchmark** to the Datasets section - a standardized benchmark for evaluating AI-generated image detectors.

## Dataset Details

| Metric | Value |
|--------|-------|
| Total Images | 2,038 |
| AI-Generated | 1,018 |
| Real Photos | 1,020 |
| AI Generators | 17 |
| Categories | 6 (Portrait, Landscape, Art, Food, Animal, Product) |

## Links

- **Website:** https://aidetectarena.com/benchmark-dataset
- **DOI:** https://doi.org/10.5281/zenodo.18620634
- **Live Leaderboard:** https://aidetectarena.com

## Why This Dataset?

- Focuses specifically on AI-generated **image** detection (complements the existing deepfake video datasets)
- Balanced dataset with equal AI/real split
- Covers 17 state-of-the-art generators (Midjourney, DALL-E, Flux, Stable Diffusion, etc.)
- Versioned for reproducible benchmarking
- Includes live leaderboard for comparing detector performance